### PR TITLE
Adding verify email

### DIFF
--- a/lib/service/auth_service.dart
+++ b/lib/service/auth_service.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:firebase_auth/firebase_auth.dart';
-import 'package:rewardscard/model/signinresult.dart';
+import '../model/signinresult.dart';
 import '../model/usermodel.dart';
 
 class AuthService {

--- a/lib/service/auth_service.dart
+++ b/lib/service/auth_service.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:google_sign_in/google_sign_in.dart';
 import 'package:firebase_auth/firebase_auth.dart';
-import '../model/signinresult.dart';
+import 'package:rewardscard/model/signinresult.dart';
 import '../model/usermodel.dart';
 
 class AuthService {
@@ -15,16 +16,26 @@ class AuthService {
     );
   }
 
-  //return current user
-  User? getCurrentUser() {
-    return _auth.currentUser;
-  }
-
   //auth changes user stream
   Stream<UserModel?> get user {
     return _auth.authStateChanges().map((User? user) {
       return _userFromFirebase(user!);
     });
+  }
+
+  //reload user from Firebase.
+  Future<void> reloadUser() async {
+    User? user = _auth.currentUser;
+    if (user == null) {
+      return;
+    } else {
+      await user.reload();
+    }
+  }
+
+  //Return current user
+  User? getCurrentUser() {
+    return _auth.currentUser;
   }
 
  
@@ -50,7 +61,6 @@ class AuthService {
   }
 
   //sign in  with email and password
-
   Future<SignInResult> signinUsingEmailPassword(
       String email, String pass) async {
     UserModel? user;
@@ -79,6 +89,7 @@ class AuthService {
     }
   }
 
+  //send reset password email (this also verifies emails)
   Future resetPassword({required String email}) async {
     try {
       return await _auth.sendPasswordResetEmail(email: email);
@@ -86,5 +97,16 @@ class AuthService {
       // ignore: avoid_print
       print(e.toString());
     }
+  }
+
+  //Send "verify email" email
+  Future<bool> sendEmailVerification() async {
+    User? user = _auth.currentUser;
+    bool rtn = false;
+    if (user != null) {
+      await user.sendEmailVerification();
+      rtn = true;
+    }
+    return rtn;
   }
 }

--- a/lib/ui/homepage.dart
+++ b/lib/ui/homepage.dart
@@ -1,6 +1,6 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
-import 'package:rewardscard/ui/login.dart';
+import 'login.dart';
 import '../service/auth_service.dart';
 
 class HomePage extends StatelessWidget {

--- a/lib/ui/homepage.dart
+++ b/lib/ui/homepage.dart
@@ -1,3 +1,4 @@
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:rewardscard/ui/login.dart';
 import '../service/auth_service.dart';
@@ -9,6 +10,7 @@ class HomePage extends StatelessWidget {
   Widget build(BuildContext context) {
     final AuthService authService = AuthService();
     final nav = Navigator.of(context);
+    final snackbar = ScaffoldMessenger.of(context);
 
     return Scaffold(
       appBar: AppBar(
@@ -22,17 +24,51 @@ class HomePage extends StatelessWidget {
                     Text('Welcome, ${AuthService().getCurrentUser()?.email}')),
           ),
           ElevatedButton(
-              onPressed: () async {
-                await authService.signout();
-                nav.pushReplacement(
-                  MaterialPageRoute(
-                      builder: (_) =>
-                          LoginPage()), // Replace with your next screen
-                );
-              },
-              child: const Text(
-                "Sign Out",
-              ))
+            onPressed: () async {
+              User? user = authService.getCurrentUser();
+              if (user?.emailVerified ?? false) {
+                snackbar.showSnackBar(
+                    const SnackBar(content: Text('Already verified!')));
+                return;
+              }
+
+              await authService.reloadUser();
+              user = authService.getCurrentUser();
+
+              if (user == null) {
+                snackbar.showSnackBar(
+                    const SnackBar(content: Text('User not found!')));
+                return;
+              }
+              if (user.emailVerified) {
+                snackbar.showSnackBar(
+                    const SnackBar(content: Text('You are now verified!')));
+                
+              } else {
+                await authService.sendEmailVerification();
+                snackbar.showSnackBar(const SnackBar(
+                    content: Text(
+                        'Check your email for verification code, then come back here to complete verification process!')));
+              }
+            },
+            child: const Text(
+              "Verify email",
+            ),
+          ),
+          TextButton(
+            onPressed: () async {
+              await authService.signout();
+              nav.pushReplacement(
+                MaterialPageRoute(
+                    builder: (_) =>
+                        LoginPage()), // Replace with your next screen
+              );
+            },
+            child: const Text(
+              "Sign Out",
+              style: TextStyle(fontSize: 14),
+            ),
+          ),
         ],
       ),
     );

--- a/lib/ui/homepage.dart
+++ b/lib/ui/homepage.dart
@@ -25,31 +25,7 @@ class HomePage extends StatelessWidget {
           ),
           ElevatedButton(
             onPressed: () async {
-              User? user = authService.getCurrentUser();
-              if (user?.emailVerified ?? false) {
-                snackbar.showSnackBar(
-                    const SnackBar(content: Text('Already verified!')));
-                return;
-              }
-
-              await authService.reloadUser();
-              user = authService.getCurrentUser();
-
-              if (user == null) {
-                snackbar.showSnackBar(
-                    const SnackBar(content: Text('User not found!')));
-                return;
-              }
-              if (user.emailVerified) {
-                snackbar.showSnackBar(
-                    const SnackBar(content: Text('You are now verified!')));
-                
-              } else {
-                await authService.sendEmailVerification();
-                snackbar.showSnackBar(const SnackBar(
-                    content: Text(
-                        'Check your email for verification code, then come back here to complete verification process!')));
-              }
+              await verifyEmail(authService, snackbar);
             },
             child: const Text(
               "Verify email",
@@ -72,5 +48,43 @@ class HomePage extends StatelessWidget {
         ],
       ),
     );
+  }
+
+  Future<void> verifyEmail(
+      AuthService authService, ScaffoldMessengerState snackbar) async {
+    //get user from service
+    User? user = authService.getCurrentUser();
+
+    //check if user is already verified and exit early if true
+    if (user?.emailVerified ?? false) {
+      snackbar.showSnackBar(const SnackBar(content: Text('Already verified!')));
+      return;
+    }
+
+    //reload user. This is necessary as the cached user isn't refreshed and the verifyEmail value never changes
+    await authService.reloadUser();
+    //get the reloaded user
+    user = authService.getCurrentUser();
+
+    //check if the user is null. This is not expected but could happen if the user is deleted since being verified
+    if (user == null) {
+      snackbar.showSnackBar(const SnackBar(content: Text('User not found!')));
+      return;
+    }
+
+    //if the user is verified after reload, display that and exit, otherwise initiate verification
+    //one downside here is that user could spam the mail by clicking this without going to her email to actually verify
+    //perhaps we should limit this to once every 3 minutes or something?
+    if (user.emailVerified) {
+      snackbar
+          .showSnackBar(const SnackBar(content: Text('You are now verified!')));
+    } else {
+      //send verification email
+      await authService.sendEmailVerification();
+      snackbar.showSnackBar(const SnackBar(
+          content: Text(
+              'Check your email for verification code, then come back here to complete verification process!')));
+    }
+    return;
   }
 }


### PR DESCRIPTION
I've added verify email functionality. 

One thing that bugs me is that the user is not automatically refreshed from Firebase. So after you verify email, this is not reflected in the user object and the `emailVerified` remains false, even after app restart! To deal with this I added `reloadUser` method to the service and am calling it from verify email button. So the workflow in that button is:

1. check if user is verified and exit early if true
2. if not reload user from Firebase
3. check if the user is verified after reload
4. if it is verified, display message an exit
5. if it is not verified, send email verification email (user could spam email server by pressing button and not actually verifying)

It's not ideal, but may do for a sample. 

Don't know if there is a better way to refresh the user. Perhaps on app startup? But then user would have to exit app after verifying email which is not ideal either!